### PR TITLE
Add Flax network for Drop Stack 2048

### DIFF
--- a/drop_stack_ai/model/network.py
+++ b/drop_stack_ai/model/network.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Tuple
+
+import jax
+import jax.numpy as jnp
+from flax import linen as nn
+
+
+class DropStackNet(nn.Module):
+    """Simple policy and value network for Drop Stack 2048."""
+
+    hidden_size: int = 128
+
+    @nn.compact
+    def __call__(self, board: jnp.ndarray, current_tile: jnp.ndarray, next_tile: jnp.ndarray) -> Tuple[jnp.ndarray, jnp.ndarray]:
+        """Forward pass.
+
+        Args:
+            board: array of shape (5, 6) with tile values.
+            current_tile: scalar array with the current tile value.
+            next_tile: scalar array with the next tile value.
+
+        Returns:
+            Tuple of ``(policy_logits, value)``.
+        """
+        # Flatten the board and take log2 encoding to keep values in a reasonable range.
+        board_flat = jnp.log2(jnp.maximum(board, 1)).reshape(-1)
+        tile_feats = jnp.log2(jnp.maximum(jnp.stack([current_tile, next_tile]), 1))
+        x = jnp.concatenate([board_flat, tile_feats], axis=0)
+
+        x = nn.Dense(self.hidden_size)(x)
+        x = nn.relu(x)
+        x = nn.Dense(self.hidden_size)(x)
+        x = nn.relu(x)
+
+        policy_logits = nn.Dense(5)(x)
+        value = nn.Dense(1)(x)
+        value = value.squeeze(axis=-1)
+        return policy_logits, value
+
+
+def create_model(rng: jax.random.PRNGKey, *, hidden_size: int = 128) -> tuple[DropStackNet, dict]:
+    """Utility to create the model and initialise its parameters on the default device."""
+    model = DropStackNet(hidden_size=hidden_size)
+    dummy_board = jnp.zeros((5, 6), jnp.float32)
+    dummy_tile = jnp.array(2, jnp.float32)
+    params = model.init(rng, dummy_board, dummy_tile, dummy_tile)
+    # Ensure parameters live on device (TPU compatible)
+    params = jax.device_put(params)
+    return model, params
+
+


### PR DESCRIPTION
## Summary
- implement a simple JAX+Flax model for Drop Stack 2048
- provide helper to create the model with parameters on device

## Testing
- `python3 - <<'PY'
import jax
import jax.numpy as jnp
from drop_stack_ai.model.network import create_model

rng = jax.random.PRNGKey(0)
model, params = create_model(rng)
board = jnp.zeros((5,6))
current_tile = jnp.array(2)
next_tile = jnp.array(4)
print(model.apply(params, board, current_tile, next_tile))
PY`

------
https://chatgpt.com/codex/tasks/task_e_6853493483808330ae7c7628296029dc