### PR TITLE
Add self-play loop and replay buffer

### DIFF
--- a/drop_stack_ai/selfplay/runner.py
+++ b/drop_stack_ai/selfplay/runner.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from typing import List, Dict, Any
+
+import jax
+import jax.numpy as jnp
+
+from ..env.drop_stack_env import DropStackEnv
+from ..model.network import DropStackNet
+from ..training.replay_buffer import ReplayBuffer
+
+
+def _state_to_arrays(state: Dict[str, Any]) -> tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray]:
+    """Convert a raw env state dict into arrays usable by the model."""
+    board = jnp.zeros((5, 6), dtype=jnp.float32)
+    for c, col in enumerate(state["board"]):
+        if col:
+            board = board.at[c, : len(col)].set(jnp.array(col, dtype=jnp.float32))
+    current = jnp.array(state["current_tile"], dtype=jnp.float32)
+    next_tile = jnp.array(state["next_tile"], dtype=jnp.float32)
+    return board, current, next_tile
+
+
+def self_play(
+    model: DropStackNet,
+    params: Dict[str, Any],
+    rng: jax.random.PRNGKey,
+    buffer: ReplayBuffer,
+    *,
+    greedy: bool = False,
+) -> jax.random.PRNGKey:
+    """Play one episode and store the experience in ``buffer``."""
+    env = DropStackEnv()
+    states: List[Dict[str, Any]] = []
+    policies: List[jnp.ndarray] = []
+    values: List[float] = []
+
+    done = False
+    while not done:
+        raw_state = env.get_state()
+        board, current, next_tile = _state_to_arrays(raw_state)
+        logits, value_pred = model.apply(params, board, current, next_tile)
+        policy = jax.nn.softmax(logits)
+
+        if greedy:
+            action = int(jnp.argmax(policy))
+        else:
+            rng, key = jax.random.split(rng)
+            action = int(jax.random.choice(key, 5, p=policy))
+
+        states.append(raw_state)
+        policies.append(policy)
+        values.append(0.0)  # placeholder
+
+        env.step(action)
+        done = env.done
+
+    # Episode finished, assign final score as the value target
+    final_score = env.score
+    values = [float(final_score)] * len(values)
+    buffer.add_episode(states, policies, values)
+    return rng

--- a/drop_stack_ai/training/replay_buffer.py
+++ b/drop_stack_ai/training/replay_buffer.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List
+
+
+@dataclass
+class ReplayBuffer:
+    """Simple in-memory replay buffer."""
+
+    data: List[Dict[str, Any]] = field(default_factory=list)
+
+    def add_episode(
+        self, states: List[Dict[str, Any]], policies: List[Any], values: List[float]
+    ) -> None:
+        """Add an episode worth of data to the buffer."""
+        for s, p, v in zip(states, policies, values):
+            self.data.append({"state": s, "policy": p, "value": v})
+
+    def __len__(self) -> int:
+        return len(self.data)
+
+    def sample(self, batch_size: int) -> List[Dict[str, Any]]:
+        """Randomly sample ``batch_size`` elements from the buffer."""
+        import random
+
+        return random.sample(self.data, batch_size)


### PR DESCRIPTION
## Summary
- implement simple `ReplayBuffer`
- add `self_play` loop for DropStack 2048

## Testing
- `python - <<'PY'
from jax import random
from drop_stack_ai.model.network import create_model
from drop_stack_ai.selfplay.runner import self_play
from drop_stack_ai.training.replay_buffer import ReplayBuffer

rng = random.PRNGKey(0)
model, params = create_model(rng)
replay = ReplayBuffer()

rng = self_play(model, params, rng, replay, greedy=True)
print('size', len(replay))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68534a12b4048330acc8b293d9c28b05