### PR TITLE
Fix imports and update env step

### DIFF
--- a/drop_stack_ai/env/drop_stack_env.py
+++ b/drop_stack_ai/env/drop_stack_env.py
@@ -111,10 +111,13 @@ class DropStackEnv:
         self.next_tile = self._spawn_tile()
         return self.get_state()
 
-    def step(self, action_col: int) -> Dict[str, object]:
-        """Drop the current tile into ``action_col``."""
+    def step(self, action_col: int) -> tuple[Dict[str, object], int, bool]:
+        """Drop the current tile into ``action_col``.
+
+        Returns a tuple of ``(next_state, reward, done)``.
+        """
         if self.done:
-            return self.get_state()
+            return self.get_state(), 0, True
 
         if action_col < 0 or action_col >= self.COLUMN_COUNT:
             raise ValueError("Invalid column")
@@ -137,7 +140,8 @@ class DropStackEnv:
         # Check for game over
         self.done = game_over(self.board, self.MAX_HEIGHT)
 
-        return self.get_state() | {"reward": reward}
+        next_state = self.get_state()
+        return next_state, reward, self.done
 
     def render(self) -> None:
         """Print the current board."""

--- a/drop_stack_ai/selfplay/runner.py
+++ b/drop_stack_ai/selfplay/runner.py
@@ -5,9 +5,9 @@ from typing import List, Dict, Any
 import jax
 import jax.numpy as jnp
 
-from ..env.drop_stack_env import DropStackEnv
-from ..model.network import DropStackNet
-from ..training.replay_buffer import ReplayBuffer
+from drop_stack_ai.env.drop_stack_env import DropStackEnv
+from drop_stack_ai.model.network import DropStackNet
+from drop_stack_ai.training.replay_buffer import ReplayBuffer
 
 
 def _state_to_arrays(state: Dict[str, Any]) -> tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray]:
@@ -52,8 +52,7 @@ def self_play(
         policies.append(policy)
         values.append(0.0)  # placeholder
 
-        env.step(action)
-        done = env.done
+        _, _, done = env.step(action)
 
     # Episode finished, assign final score as the value target
     final_score = env.score

--- a/drop_stack_ai/training/train.py
+++ b/drop_stack_ai/training/train.py
@@ -9,7 +9,7 @@ from flax import linen as nn
 from flax.training import train_state
 import optax
 
-from ..model.network import DropStackNet, create_model
+from drop_stack_ai.model.network import DropStackNet, create_model
 from .replay_buffer import ReplayBuffer
 
 


### PR DESCRIPTION
## Summary
- return `(next_state, reward, done)` from env.step
- adjust self-play to handle new step return
- use absolute imports for easier script execution

## Testing
- `python - <<'PY'
from drop_stack_ai.env.drop_stack_env import DropStackEnv
env = DropStackEnv()
next_state, reward, done = env.step(0)
print('keys', next_state.keys(), 'reward', reward, 'done', done)
PY`
- `python - <<'PY'
from drop_stack_ai.selfplay.runner import self_play
from drop_stack_ai.model.network import create_model
from drop_stack_ai.training.replay_buffer import ReplayBuffer
import jax
rng = jax.random.PRNGKey(0)
model, params = create_model(rng)
buffer = ReplayBuffer()
self_play(model, params, rng, buffer, greedy=True)
print('buffer size', len(buffer))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68543da727188330b0b0a4811763ef39