### PR TITLE
Fix training script dataclass usage

### DIFF
--- a/drop_stack_ai/training/train.py
+++ b/drop_stack_ai/training/train.py
@@ -157,4 +157,5 @@ if __name__ == "__main__":
     }
     dummy_policy = jnp.ones(5, dtype=jnp.float32) / 5
     buffer.add_episode([env_state], [dummy_policy], [0.0])
-    train(buffer, steps=5)
+    config = TrainConfig(batch_size=1, steps=5)
+    train(buffer, config=config)


### PR DESCRIPTION
## Summary
- set up TrainConfig with small batch size before training

## Testing
- `python -m py_compile drop_stack_ai/training/train.py`


------
https://chatgpt.com/codex/tasks/task_e_68544403be4c8330be56e66baf74c279