### PR TITLE
Handle mismatched batch size and device count

### DIFF
--- a/drop_stack_ai/training/train.py
+++ b/drop_stack_ai/training/train.py
@@ -120,6 +120,14 @@ def train(buffer: ReplayBuffer, *, seed: int = 0, config: TrainConfig | None = N
     n_devices = len(devices)
     print(f"Using {n_devices} device(s) for training")
 
+    if config.batch_size < n_devices or config.batch_size % n_devices != 0:
+        print(
+            "Warning: batch size does not align with available devices; "
+            "falling back to single-device mode"
+        )
+        devices = [devices[0]]
+        n_devices = 1
+
     if n_devices > 1:
         state = jax.device_put_replicated(state, devices)
         update_fn = pmap_update_fn(model)


### PR DESCRIPTION
## Summary
- detect mismatched batch size and number of devices in training
- fall back to single-device mode with a warning when the batch size is unsuitable

## Testing
- `python -m compileall -q drop_stack_ai`

------
https://chatgpt.com/codex/tasks/task_e_685444e0b8a083309cd158db789fcd74