### PR TITLE
Expose jax traceback option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
 # drop-stack-2048-ai
+
+The training code sets a default value for the `JAX_TRACEBACK_FILTERING`
+environment variable to disable traceback filtering. If you want different
+behaviour, you can override this variable before running the training
+scripts.

--- a/drop_stack_ai/training/train.py
+++ b/drop_stack_ai/training/train.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Dict
 
+import os
+os.environ.setdefault("JAX_TRACEBACK_FILTERING", "off")
+
 import jax
 import jax.numpy as jnp
 from flax import linen as nn


### PR DESCRIPTION
## Summary
- allow users to override `JAX_TRACEBACK_FILTERING` by setting a default before JAX imports
- mention the env var override in the README

## Testing
- `python -m drop_stack_ai.training.train`


------
https://chatgpt.com/codex/tasks/task_e_68544690dd308330a02e1340b1470dba