### PR TITLE
Use log of final score for value targets

### DIFF
--- a/drop_stack_ai/selfplay/runner.py
+++ b/drop_stack_ai/selfplay/runner.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import List, Dict, Any
 
+import math
+
 import jax
 import jax.numpy as jnp
 
@@ -55,7 +57,7 @@ def self_play(
         _, _, done = env.step(action)
 
     # Episode finished, assign final score as the value target
-    final_score = env.score
+    final_score = math.log(env.score + 1)
     values = [float(final_score)] * len(values)
     buffer.add_episode(states, policies, values)
     return rng


### PR DESCRIPTION
## Summary
- compute log(final score + 1) when storing value targets

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854e4ae4d9483308a7f47bcf8b02b8f