### PR TITLE
Implement MCTS-based self-play helper

### DIFF
--- a/drop_stack_ai/selfplay/self_play.py
+++ b/drop_stack_ai/selfplay/self_play.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from typing import List, Dict, Any
+
+import math
+
+import jax
+import jax.numpy as jnp
+
+from drop_stack_ai.env.drop_stack_env import DropStackEnv
+from drop_stack_ai.model.network import DropStackNet
+from drop_stack_ai.model.mcts import run_mcts
+from drop_stack_ai.training.replay_buffer import ReplayBuffer
+
+
+def self_play(
+    model: DropStackNet,
+    params: Dict[str, Any],
+    rng: jax.random.PRNGKey,
+    buffer: ReplayBuffer,
+    *,
+    greedy: bool = False,
+    simulations: int = 50,
+    c_puct: float = 1.0,
+) -> jax.random.PRNGKey:
+    """Run a single self-play episode using MCTS.
+
+    At every step an MCTS search is performed starting from the current
+    environment state. The resulting visit counts are normalised and stored as
+    the policy target. Moves are selected proportionally to this distribution
+    when ``greedy`` is ``False`` and greedily otherwise.
+    """
+    env = DropStackEnv()
+    states: List[Dict[str, Any]] = []
+    policies: List[jnp.ndarray] = []
+    values: List[float] = []
+
+    done = False
+    while not done:
+        raw_state = env.get_state()
+        policy = run_mcts(
+            model,
+            params,
+            env,
+            num_simulations=simulations,
+            c_puct=c_puct,
+        )
+
+        if greedy:
+            action = int(jnp.argmax(policy))
+        else:
+            rng, key = jax.random.split(rng)
+            action = int(jax.random.choice(key, 5, p=policy))
+
+        states.append(raw_state)
+        policies.append(policy)
+        values.append(0.0)  # placeholder
+
+        _, _, done = env.step(action)
+
+    # Episode finished, assign final score as the value target
+    final_score = math.log(env.score + 1)
+    values = [float(final_score)] * len(values)
+    buffer.add_episode(states, policies, values)
+    return rng

--- a/drop_stack_ai/training/train.py
+++ b/drop_stack_ai/training/train.py
@@ -15,7 +15,7 @@ from flax.training import train_state
 import optax
 
 from drop_stack_ai.model.network import DropStackNet, create_model
-from drop_stack_ai.selfplay.runner import self_play
+from drop_stack_ai.selfplay.self_play import self_play
 from .replay_buffer import ReplayBuffer
 
 


### PR DESCRIPTION
## Summary
- add `self_play.py` containing the self-play loop
- reference the new self-play helper in the training script

## Testing
- `python -m drop_stack_ai.training.train --help`
- `python -m compileall drop_stack_ai`

------
https://chatgpt.com/codex/tasks/task_e_6855021ead48833098e85692bfa579e2