### PR TITLE
Improve replay buffer management

### DIFF
--- a/drop_stack_ai/training/replay_buffer.py
+++ b/drop_stack_ai/training/replay_buffer.py
@@ -2,20 +2,40 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from typing import Any, Dict, List
+from collections import deque
 
 
 @dataclass
 class ReplayBuffer:
-    """Simple in-memory replay buffer."""
+    """Simple replay buffer storing recent episodes."""
 
+    max_episodes: int = 1000
     data: List[Dict[str, Any]] = field(default_factory=list)
+    episodes: deque = field(init=False)
+
+    def __post_init__(self) -> None:
+        # ``episodes`` tracks the individual episodes so old ones can be
+        # discarded once ``max_episodes`` is exceeded.
+        self.episodes = deque()
+        if self.data:
+            # Assume entire data belongs to a single episode when loading from
+            # legacy buffers.
+            self.episodes.append(list(self.data))
 
     def add_episode(
         self, states: List[Dict[str, Any]], policies: List[Any], values: List[float]
     ) -> None:
         """Add an episode worth of data to the buffer."""
+        episode = []
         for s, p, v in zip(states, policies, values):
-            self.data.append({"state": s, "policy": p, "value": v})
+            item = {"state": s, "policy": p, "value": v}
+            episode.append(item)
+            self.data.append(item)
+
+        self.episodes.append(episode)
+        while len(self.episodes) > self.max_episodes:
+            old = self.episodes.popleft()
+            del self.data[: len(old)]
 
     def __len__(self) -> int:
         return len(self.data)


### PR DESCRIPTION
## Summary
- keep track of episodes and drop old ones
- maintain a maximum of recent episodes in the replay buffer

## Testing
- `python -m py_compile drop_stack_ai/training/replay_buffer.py`
- `python -m py_compile drop_stack_ai/selfplay/runner.py drop_stack_ai/selfplay/self_play.py drop_stack_ai/training/train.py`
- `python -m compileall -q drop_stack_ai`
- `python - <<'PY'
from drop_stack_ai.training.replay_buffer import ReplayBuffer
rb = ReplayBuffer(max_episodes=3)
for ep in range(5):
    rb.add_episode([{'s':ep}], [ep], [ep])
    print(len(rb), len(rb.episodes))
PY`

------
https://chatgpt.com/codex/tasks/task_e_6855076ad174833087d074dc49a36ff3