### PR TITLE
Add checkpoint saving and loading

### DIFF
--- a/checkpoints/README.md
+++ b/checkpoints/README.md
@@ -1,0 +1,1 @@
+This directory stores training checkpoints.

--- a/drop_stack_ai/utils/serialization.py
+++ b/drop_stack_ai/utils/serialization.py
@@ -1,0 +1,18 @@
+import os
+from typing import Any
+
+from flax.serialization import to_bytes, from_bytes
+
+
+def save_params(params: Any, path: str) -> None:
+    """Save model parameters to ``path`` using Flax serialization."""
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "wb") as f:
+        f.write(to_bytes(params))
+
+
+def load_params(path: str, target: Any) -> Any:
+    """Load parameters from ``path`` into ``target`` structure."""
+    with open(path, "rb") as f:
+        data = f.read()
+    return from_bytes(target, data)

--- a/main.py
+++ b/main.py
@@ -35,6 +35,12 @@ def main() -> None:
     parser.add_argument("--batch-size", type=int, default=32, help="Batch size")
     parser.add_argument("--learning-rate", type=float, default=1e-3, help="Learning rate")
     parser.add_argument("--hidden-size", type=int, default=128, help="Model hidden size")
+    parser.add_argument(
+        "--checkpoint",
+        type=str,
+        default=os.path.join("checkpoints", "model.msgpack"),
+        help="Path to save or load model parameters",
+    )
     parser.add_argument("--seed", type=int, default=0, help="Random seed")
     args = parser.parse_args()
 
@@ -45,6 +51,7 @@ def main() -> None:
         steps=args.steps,
         learning_rate=args.learning_rate,
         hidden_size=args.hidden_size,
+        checkpoint_path=args.checkpoint,
     )
     run_cycle(args.episodes, args.seed, config)
 


### PR DESCRIPTION
## Summary
- create `checkpoints/` directory with README
- implement utility helpers for saving/loading params
- support checkpoint load/save in training script
- pass checkpoint argument through `main.py`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68560ce8a1d08330873e28dea6b548dd