### PR TITLE
Add checkpoint resume across multiple training cycles

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ This repository provides a simple AlphaZero-style training pipeline for the
 Drop Stack 2048 game. The new `main.py` script runs a full cycle consisting of
 self-play data generation followed by network training.
 
+The script now supports running multiple cycles in succession using the
+``--cycles`` flag. Each cycle loads the latest checkpoint (if present) before
+starting self-play so training can continue from the previously saved model.
+
 The training code sets a default value for the `JAX_TRACEBACK_FILTERING`
 environment variable to disable traceback filtering. If you want different
 behaviour, you can override this variable before running the training scripts.


### PR DESCRIPTION
## Summary
- load existing model checkpoint before self-play
- add `--cycles` argument to run several training cycles sequentially
- document the new behaviour in README

## Testing
- `python -m py_compile main.py drop_stack_ai/training/train.py`


------
https://chatgpt.com/codex/tasks/task_e_6856539a564083309966e5ea34543a43