### PR TITLE
Implement score-based model promotion

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ The script now supports running multiple cycles in succession using the
 ``--cycles`` flag. Each cycle loads the latest checkpoint (if present) before
 starting self-play so training can continue from the previously saved model.
 
+After each training cycle the new model plays a set of test games to measure
+its average score. If this score beats the previous best, the checkpoint is
+promoted and stored alongside the current best score.
+
 The training code sets a default value for the `JAX_TRACEBACK_FILTERING`
 environment variable to disable traceback filtering. If you want different
 behaviour, you can override this variable before running the training scripts.

--- a/drop_stack_ai/selfplay/evaluate.py
+++ b/drop_stack_ai/selfplay/evaluate.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from typing import Dict
+
+import jax
+import jax.numpy as jnp
+
+from drop_stack_ai.env.drop_stack_env import DropStackEnv
+from drop_stack_ai.model.network import DropStackNet
+from drop_stack_ai.model.mcts import run_mcts
+
+
+def play_game(
+    model: DropStackNet,
+    params: Dict,
+    rng: jax.random.PRNGKey,
+    *,
+    simulations: int = 50,
+    c_puct: float = 1.0,
+) -> tuple[jax.random.PRNGKey, int]:
+    """Play a single game greedily and return the score."""
+    env = DropStackEnv(seed=int(jax.random.randint(rng, (), 0, 2**31 - 1)))
+    done = False
+    while not done:
+        policy = run_mcts(
+            model,
+            params,
+            env,
+            num_simulations=simulations,
+            c_puct=c_puct,
+        )
+        action = int(jnp.argmax(policy))
+        _, _, done = env.step(action)
+    return rng, env.score
+
+
+def evaluate_model(
+    model: DropStackNet,
+    params: Dict,
+    *,
+    games: int = 50,
+    seed: int = 0,
+    simulations: int = 50,
+    c_puct: float = 1.0,
+) -> float:
+    """Return the average score over ``games`` greedy self-play episodes."""
+    rng = jax.random.PRNGKey(seed)
+    total = 0.0
+    for _ in range(games):
+        rng, key = jax.random.split(rng)
+        key, score = play_game(
+            model,
+            params,
+            key,
+            simulations=simulations,
+            c_puct=c_puct,
+        )
+        total += score
+    return total / games


### PR DESCRIPTION
## Summary
- add evaluation helper to compute average score
- track best model using average score
- promote a checkpoint if it improves on the previous best
- document score-based evaluation in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685654b5a19c83309a409474895f82c0