### PR TITLE
Add exploration-to-greedy self-play phase

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ The script now supports running multiple cycles in succession using the
 ``--cycles`` flag. Each cycle loads the latest checkpoint (if present) before
 starting self-play so training can continue from the previously saved model.
 
+Self-play uses Monte Carlo Tree Search to select actions. Early in each game the
+agent samples moves in proportion to the MCTS visit counts. The `--greedy-after`
+flag controls after how many moves the policy becomes greedy and always selects
+the most-visited action.
+
 After each training cycle the new model plays a set of test games to measure
 its average score. If this score beats the previous best, the checkpoint is
 promoted and stored alongside the current best score.

--- a/drop_stack_ai/training/train.py
+++ b/drop_stack_ai/training/train.py
@@ -199,6 +199,12 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Train Drop Stack 2048 model")
     parser.add_argument("--buffer", type=str, help="Path to replay buffer pickle")
     parser.add_argument("--self-play", type=int, default=0, help="Generate this many self-play episodes before training")
+    parser.add_argument(
+        "--greedy-after",
+        type=int,
+        default=10,
+        help="Number of moves to sample probabilistically before switching to greedy play during self-play",
+    )
     parser.add_argument("--steps", type=int, default=1000, help="Number of training steps")
     parser.add_argument("--batch-size", type=int, default=32, help="Batch size")
     parser.add_argument("--learning-rate", type=float, default=1e-3, help="Learning rate")
@@ -221,7 +227,7 @@ if __name__ == "__main__":
     if args.self_play > 0:
         model, params = create_model(rng, hidden_size=args.hidden_size)
         for _ in range(args.self_play):
-            rng = self_play(model, params, rng, buffer)
+            rng = self_play(model, params, rng, buffer, greedy_after=args.greedy_after)
 
     if len(buffer) == 0:
         raise ValueError("Replay buffer is empty")


### PR DESCRIPTION
## Summary
- extend self-play to sample actions for a number of moves then switch to greedy
- expose the new behaviour through `--greedy-after` option in `main.py` and the training script
- document the exploration phase

## Testing
- `python -m drop_stack_ai.training.train -h`
- `python main.py -h`
- `python - <<'EOF'
import jax
from drop_stack_ai.model.network import create_model
from drop_stack_ai.selfplay.self_play import self_play
from drop_stack_ai.training.replay_buffer import ReplayBuffer
rng = jax.random.PRNGKey(0)
model, params = create_model(rng)
buffer = ReplayBuffer()
rng = self_play(model, params, rng, buffer, greedy_after=2)
print('episode len', len(buffer.data[0]['state']))
EOF

------
https://chatgpt.com/codex/tasks/task_e_68565715aaac833099ffeffe98d95d2d