### PR TITLE
Deduplicate state_to_arrays helper

### DIFF
--- a/drop_stack_ai/model/mcts.py
+++ b/drop_stack_ai/model/mcts.py
@@ -9,19 +9,7 @@ import jax.numpy as jnp
 
 from drop_stack_ai.env.drop_stack_env import DropStackEnv
 from .network import DropStackNet
-
-
-def _state_to_arrays(
-    state: Dict[str, object],
-) -> tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray]:
-    """Convert env state dict into arrays for the model."""
-    board = jnp.zeros((5, 6), dtype=jnp.float32)
-    for c, col in enumerate(state["board"]):
-        if col:
-            board = board.at[c, : len(col)].set(jnp.array(col, dtype=jnp.float32))
-    current = jnp.array(state["current_tile"], dtype=jnp.float32)
-    next_tile = jnp.array(state["next_tile"], dtype=jnp.float32)
-    return board, current, next_tile
+from drop_stack_ai.utils.state_utils import state_to_arrays
 
 
 @dataclass
@@ -83,7 +71,7 @@ def run_mcts(
         if sim_env.done:
             value = math.log(sim_env.score + 1)
         else:
-            board, current, next_tile = _state_to_arrays(sim_env.get_state())
+            board, current, next_tile = state_to_arrays(sim_env.get_state())
             logits, value_pred = model.apply(params, board, current, next_tile)
             policy = jax.nn.softmax(logits)
             if not node.children:

--- a/drop_stack_ai/utils/state_utils.py
+++ b/drop_stack_ai/utils/state_utils.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+import jax.numpy as jnp
+
+
+def state_to_arrays(
+    state: Dict[str, Any],
+) -> tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray]:
+    """Convert env state dict into arrays for the model."""
+    board = jnp.zeros((5, 6), dtype=jnp.float32)
+    for c, col in enumerate(state["board"]):
+        if col:
+            board = board.at[c, : len(col)].set(jnp.array(col, dtype=jnp.float32))
+    current = jnp.array(state["current_tile"], dtype=jnp.float32)
+    next_tile = jnp.array(state["next_tile"], dtype=jnp.float32)
+    return board, current, next_tile


### PR DESCRIPTION
## Summary
- add `state_to_arrays` utility for shared conversion of environment state
- use the helper in MCTS and training code
- remove duplicate implementations

## Testing
- `black --check drop_stack_ai/utils/state_utils.py drop_stack_ai/model/mcts.py drop_stack_ai/training/train.py`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68566175d40083309da6a056deff229f