### PR TITLE
Use spawn start method in multiprocessing

### DIFF
--- a/drop_stack_ai/selfplay/self_play.py
+++ b/drop_stack_ai/selfplay/self_play.py
@@ -145,7 +145,8 @@ def self_play_parallel(
         for seed in seeds
     ]
 
-    with mp.Pool(processes) as pool:
+    ctx = mp.get_context("spawn")
+    with ctx.Pool(processes) as pool:
         results = pool.map(_worker, args)
 
     for states, policies, values in results:


### PR DESCRIPTION
## Summary
- avoid JAX fork warnings by spawning worker processes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856743fbf5c8330811a66cab474c6fb