### PR TITLE
Remove unused imports

### DIFF
--- a/drop_stack_ai/env/drop_stack_env.py
+++ b/drop_stack_ai/env/drop_stack_env.py
@@ -7,7 +7,6 @@ from collections import deque
 from typing import Dict, List
 
 from .merge import (
-    drop_and_resolve,
     drop_resolve_and_score,
     print_board,
     game_over,

--- a/drop_stack_ai/model/mcts.py
+++ b/drop_stack_ai/model/mcts.py
@@ -6,7 +6,6 @@ import math
 
 import jax
 import jax.numpy as jnp
-import functools
 
 from drop_stack_ai.env.drop_stack_env import DropStackEnv
 from .network import DropStackNet

--- a/drop_stack_ai/training/train.py
+++ b/drop_stack_ai/training/train.py
@@ -6,7 +6,6 @@ from typing import Any, Dict, Optional
 import os
 import argparse
 import pickle
-import threading
 import time
 
 os.environ.setdefault("JAX_TRACEBACK_FILTERING", "off")


### PR DESCRIPTION
## Summary
- drop unused functools import from mcts
- drop unused threading import from training script
- drop unused drop_and_resolve import from env

## Testing
- `python -m compileall -q drop_stack_ai`

------
https://chatgpt.com/codex/tasks/task_e_68571975c2308330b3f2b9c79286edbc