### PR TITLE
Increase default replay buffer size

### DIFF
--- a/drop_stack_ai/training/replay_buffer.py
+++ b/drop_stack_ai/training/replay_buffer.py
@@ -9,7 +9,7 @@ from collections import deque
 class ReplayBuffer:
     """Simple replay buffer storing recent episodes."""
 
-    max_episodes: int = 1000
+    max_episodes: int = 200_000
     data: List[Dict[str, Any]] = field(default_factory=list)
     episodes: deque = field(init=False)
 

--- a/drop_stack_ai/training/train.py
+++ b/drop_stack_ai/training/train.py
@@ -89,7 +89,7 @@ class TrainConfig:
     log_interval: int = 10
     checkpoint_path: Optional[str] = None
     workers: int = 0
-    buffer_size: int = 1000
+    buffer_size: int = 200_000
     greedy_after: int | None = 10
 
 
@@ -260,7 +260,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--buffer-size",
         type=int,
-        default=1000,
+        default=200_000,
         help="Maximum episodes to store in the replay buffer",
     )
     parser.add_argument(


### PR DESCRIPTION
## Summary
- bump the default replay buffer capacity to 200k episodes

## Testing
- `pip install -e . --no-build-isolation`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857733e4e0883309a849b8b8d9b1a3f