### PR TITLE
Enable async loading and mixed precision

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ agent samples moves in proportion to the MCTS visit counts. The `--greedy-after`
 flag controls after how many moves the policy becomes greedy and always selects
 the most-visited action.
 
+Training uses an asynchronous data loader that prefetches batches on a
+background thread so the GPU remains busy. Mixed precision can be enabled with
+the `--mixed-precision` flag to reduce memory usage and speed up training.
+
 You can speed up data generation by running multiple self-play episodes in
 parallel using the `--processes` option.
 

--- a/drop_stack_ai/model/network.py
+++ b/drop_stack_ai/model/network.py
@@ -11,6 +11,7 @@ class DropStackNet(nn.Module):
     """Simple policy and value network for Drop Stack 2048."""
 
     hidden_size: int = 128
+    dtype: jnp.dtype = jnp.float32
 
     @nn.compact
     def __call__(self, board: jnp.ndarray, current_tile: jnp.ndarray, next_tile: jnp.ndarray) -> Tuple[jnp.ndarray, jnp.ndarray]:
@@ -40,22 +41,27 @@ class DropStackNet(nn.Module):
             tile_feats = jnp.log2(jnp.maximum(jnp.stack([current_tile, next_tile]), 1))
             x = jnp.concatenate([board_flat, tile_feats], axis=0)
 
-        x = nn.Dense(self.hidden_size)(x)
+        x = nn.Dense(self.hidden_size, dtype=self.dtype)(x)
         x = nn.relu(x)
-        x = nn.Dense(self.hidden_size)(x)
+        x = nn.Dense(self.hidden_size, dtype=self.dtype)(x)
         x = nn.relu(x)
 
         # Two separate heads: policy provides logits for MCTS priors, value
         # produces a scalar evaluation of the current position.
-        policy_logits = nn.Dense(5)(x)
-        value = nn.Dense(1)(x)
+        policy_logits = nn.Dense(5, dtype=self.dtype)(x)
+        value = nn.Dense(1, dtype=self.dtype)(x)
         value = value.squeeze(axis=-1)
-        return policy_logits, value
+        return policy_logits.astype(jnp.float32), value.astype(jnp.float32)
 
 
-def create_model(rng: jax.random.PRNGKey, *, hidden_size: int = 128) -> tuple[DropStackNet, dict]:
+def create_model(
+    rng: jax.random.PRNGKey,
+    *,
+    hidden_size: int = 128,
+    dtype: jnp.dtype = jnp.float32,
+) -> tuple[DropStackNet, dict]:
     """Utility to create the model and initialise its parameters on the default device."""
-    model = DropStackNet(hidden_size=hidden_size)
+    model = DropStackNet(hidden_size=hidden_size, dtype=dtype)
     dummy_board = jnp.zeros((5, 6), jnp.float32)
     dummy_tile = jnp.array(2, jnp.float32)
     params = model.init(rng, dummy_board, dummy_tile, dummy_tile)

--- a/drop_stack_ai/training/data_loader.py
+++ b/drop_stack_ai/training/data_loader.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+__all__ = ["data_loader"]
+
+import threading
+import time
+from queue import Queue
+from typing import Iterator, Dict, Any
+
+import jax
+import jax.numpy as jnp
+
+from .replay_buffer import ReplayBuffer
+from drop_stack_ai.utils.state_utils import state_to_arrays
+
+
+def _prepare_batch(samples: list[Dict[str, Any]]) -> Dict[str, jnp.ndarray]:
+    boards = []
+    currents = []
+    nexts = []
+    policies = []
+    values = []
+    for item in samples:
+        b, c, n = state_to_arrays(item["state"])
+        boards.append(b)
+        currents.append(c)
+        nexts.append(n)
+        policy = jnp.array(item["policy"], dtype=jnp.float32)
+        if policy.ndim == 1 and policy.sum() != 0:
+            policy = policy / policy.sum()
+        policies.append(policy)
+        values.append(jnp.array(item["value"], dtype=jnp.float32))
+    return {
+        "board": jnp.stack(boards),
+        "current": jnp.stack(currents),
+        "next": jnp.stack(nexts),
+        "policy": jnp.stack(policies),
+        "value": jnp.stack(values),
+    }
+
+
+def _prefetch_generator(gen: Iterator[Dict[str, jnp.ndarray]], size: int) -> Iterator[Dict[str, jnp.ndarray]]:
+    queue: Queue = Queue(maxsize=size)
+    stop = object()
+
+    def _loop() -> None:
+        for item in gen:
+            queue.put(item)
+        queue.put(stop)
+
+    thread = threading.Thread(target=_loop, daemon=True)
+    thread.start()
+
+    while True:
+        item = queue.get()
+        if item is stop:
+            return
+        yield item
+
+
+def data_loader(
+    buffer: ReplayBuffer,
+    batch_size: int,
+    *,
+    devices: list[jax.Device],
+    prefetch: int = 2,
+) -> Iterator[Dict[str, jnp.ndarray]]:
+    n_devices = len(devices)
+
+    def _iterator() -> Iterator[Dict[str, jnp.ndarray]]:
+        while True:
+            while len(buffer) < batch_size:
+                time.sleep(0.01)
+            samples = buffer.sample(batch_size)
+            batch = _prepare_batch(samples)
+            if n_devices > 1:
+                per_dev = batch_size // n_devices
+                batch = {
+                    k: v.reshape((n_devices, per_dev) + v.shape[1:])
+                    for k, v in batch.items()
+                }
+                batch = {
+                    k: jax.device_put_sharded(list(v), devices)
+                    for k, v in batch.items()
+                }
+            else:
+                batch = jax.device_put(batch, devices[0])
+            yield batch
+
+    return _prefetch_generator(_iterator(), prefetch)


### PR DESCRIPTION
## Summary
- create async data_loader with prefetch to device
- support mixed precision via config flag and dtype-aware models
- raise training defaults to large scale values
- expose mixed precision flag in main script
- document async loader and mixed precision in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python main.py --help` *(fails: ModuleNotFoundError: No module named 'jax')*


------
https://chatgpt.com/codex/tasks/task_e_6857767856408330aeb9e170ab595a48