### PR TITLE
Fix dtype string for self-play workers

### DIFF
--- a/drop_stack_ai/selfplay/self_play.py
+++ b/drop_stack_ai/selfplay/self_play.py
@@ -143,7 +143,7 @@ def self_play_parallel(
     rng = keys[0]
     seeds = [int(jax.random.randint(k, (), 0, 2**31 - 1)) for k in keys[1:]]
 
-    dtype_name = str(model.dtype).split(".")[-1]
+    dtype_name = jnp.dtype(model.dtype).name
     args = [
         (
             seed,


### PR DESCRIPTION
## Summary
- fix how the dtype name is extracted in `self_play_parallel`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68577d0a34e08330b82b7512e7131511