### PR TITLE
Update default run parameters

### DIFF
--- a/drop_stack_ai/training/train.py
+++ b/drop_stack_ai/training/train.py
@@ -50,7 +50,7 @@ def load_buffer(path: str) -> ReplayBuffer:
 @dataclass
 class TrainConfig:
     batch_size: int = 256
-    steps: int = 1_000_000
+    steps: int = 100_000
     learning_rate: float = 2e-3
     hidden_size: int = 1024
     log_interval: int = 10
@@ -226,7 +226,7 @@ if __name__ == "__main__":
         help="Maximum episodes to store in the replay buffer",
     )
     parser.add_argument(
-        "--steps", type=int, default=1_000_000, help="Number of training steps"
+        "--steps", type=int, default=100_000, help="Number of training steps"
     )
     parser.add_argument("--batch-size", type=int, default=256, help="Batch size")
     parser.add_argument(

--- a/main.py
+++ b/main.py
@@ -80,8 +80,8 @@ def run_cycle(
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Run Drop Stack 2048 training cycle")
-    parser.add_argument("--episodes", type=int, default=100000, help="Number of self-play episodes")
-    parser.add_argument("--steps", type=int, default=1000000, help="Training steps")
+    parser.add_argument("--episodes", type=int, default=20000, help="Number of self-play episodes")
+    parser.add_argument("--steps", type=int, default=100000, help="Training steps")
     parser.add_argument("--batch-size", type=int, default=256, help="Batch size")
     parser.add_argument("--learning-rate", type=float, default=2e-3, help="Learning rate")
     parser.add_argument("--hidden-size", type=int, default=1024, help="Model hidden size")
@@ -97,7 +97,7 @@ def main() -> None:
         help="Path to save or load model parameters",
     )
     parser.add_argument("--seed", type=int, default=0, help="Random seed")
-    parser.add_argument("--cycles", type=int, default=1, help="Number of training cycles to run")
+    parser.add_argument("--cycles", type=int, default=20, help="Number of training cycles to run")
     parser.add_argument(
         "--greedy-after",
         type=int,


### PR DESCRIPTION
## Summary
- use 20k episodes and 20 cycles by default
- reduce training steps to 100k

## Testing
- `python -m compileall -q .`

------
https://chatgpt.com/codex/tasks/task_e_68578ece1f7c833083041d1a97bd4fb8