### PR TITLE
Optimize JAX JIT reuse across MCTS calls

### DIFF
--- a/drop_stack_ai/model/mcts.py
+++ b/drop_stack_ai/model/mcts.py
@@ -49,12 +49,20 @@ def run_mcts(
     *,
     num_simulations: int = 50,
     c_puct: float = 1.0,
+    predict=None,
 ) -> jnp.ndarray:
-    """Run MCTS starting from ``env`` state and return a policy distribution."""
+    """Run MCTS starting from ``env`` state and return a policy distribution.
+
+    The ``predict`` argument should be a JIT compiled version of
+    ``model.apply``. Passing a pre-compiled function avoids recompiling the
+    network on every call which can become costly when MCTS is invoked many
+    times.  If ``predict`` is ``None`` a compiled version is created on the
+    first call.
+    """
     root = Node(prior=1.0)
 
-    # JIT compile the network forward pass for better MCTS performance
-    predict = jax.jit(model.apply)
+    if predict is None:
+        predict = jax.jit(model.apply)
 
     for _ in range(num_simulations):
         sim_env = env.clone()

--- a/drop_stack_ai/selfplay/self_play.py
+++ b/drop_stack_ai/selfplay/self_play.py
@@ -31,6 +31,7 @@ def _play_episode(
 ]:
     """Return data for a single self-play episode."""
     env = DropStackEnv()
+    predict = jax.jit(model.apply)
     states: List[Dict[str, Any]] = []
     policies: List[jnp.ndarray] = []
     values: List[float] = []
@@ -45,6 +46,7 @@ def _play_episode(
             env,
             num_simulations=simulations,
             c_puct=c_puct,
+            predict=predict,
         )
 
         use_greedy = greedy or (greedy_after is not None and step >= greedy_after)


### PR DESCRIPTION
## Summary
- add an optional `predict` argument to `run_mcts` so callers can provide a pre-jitted model
- compile the model once inside self-play and evaluation helpers and reuse it for all tree searches

## Testing
- `python -m py_compile drop_stack_ai/model/mcts.py drop_stack_ai/selfplay/self_play.py drop_stack_ai/selfplay/evaluate.py`
- `python - <<'PY'
import jax
import drop_stack_ai
from drop_stack_ai.model.network import create_model
from drop_stack_ai.selfplay.evaluate import evaluate_model

rng = jax.random.PRNGKey(0)
model, params = create_model(rng)
print('Eval start')
score = evaluate_model(model, params, games=1)
print('score', score)
PY

------
https://chatgpt.com/codex/tasks/task_e_685d7f18e7e083309a20dbf9ae0ad6ce