### PR TITLE
Lower default MCTS simulations

### DIFF
--- a/drop_stack_ai/model/mcts.py
+++ b/drop_stack_ai/model/mcts.py
@@ -47,7 +47,7 @@ def run_mcts(
     params: Dict,
     env: DropStackEnv,
     *,
-    num_simulations: int = 50,
+    num_simulations: int = 20,
     c_puct: float = 1.0,
     predict=None,
 ) -> jnp.ndarray:

--- a/drop_stack_ai/selfplay/evaluate.py
+++ b/drop_stack_ai/selfplay/evaluate.py
@@ -15,7 +15,7 @@ def play_game(
     params: Dict,
     rng: jax.random.PRNGKey,
     *,
-    simulations: int = 50,
+    simulations: int = 20,
     c_puct: float = 1.0,
     predict=None,
 ) -> tuple[jax.random.PRNGKey, int]:
@@ -44,7 +44,7 @@ def evaluate_model(
     *,
     games: int = 50,
     seed: int = 0,
-    simulations: int = 50,
+    simulations: int = 20,
     c_puct: float = 1.0,
 ) -> float:
     """Return the average score over ``games`` greedy self-play episodes."""

--- a/drop_stack_ai/selfplay/self_play.py
+++ b/drop_stack_ai/selfplay/self_play.py
@@ -24,7 +24,7 @@ def _play_episode(
     *,
     greedy: bool = False,
     greedy_after: int | None = None,
-    simulations: int = 50,
+    simulations: int = 20,
     c_puct: float = 1.0,
 ) -> Tuple[
     jax.random.PRNGKey, List[Dict[str, Any]], List[jnp.ndarray], List[float], int
@@ -76,7 +76,7 @@ def self_play(
     *,
     greedy: bool = False,
     greedy_after: int | None = None,
-    simulations: int = 50,
+    simulations: int = 20,
     c_puct: float = 1.0,
 ) -> jax.random.PRNGKey:
     """Run a single self-play episode using MCTS and store it in ``buffer``."""
@@ -135,7 +135,7 @@ def self_play_parallel(
     processes: int | None = None,
     greedy: bool = False,
     greedy_after: int | None = None,
-    simulations: int = 50,
+    simulations: int = 20,
     c_puct: float = 1.0,
 ) -> jax.random.PRNGKey:
     """Run ``episodes`` self-play games in parallel."""
@@ -195,7 +195,7 @@ def launch_self_play_workers(
     workers: int,
     greedy: bool = False,
     greedy_after: int | None = None,
-    simulations: int = 50,
+    simulations: int = 20,
     c_puct: float = 1.0,
 ) -> threading.Event:
     """Start background self-play workers that continuously fill ``buffer``."""


### PR DESCRIPTION
## Summary
- speed up early training by decreasing the default number of Monte Carlo tree search simulations

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d831a599c8330a3a29031b85d6e67