### PR TITLE
Add asynchronous training pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,11 @@ training step uses a GPU. JAX may report errors such as::
 
 These messages are harmless and simply indicate that the workers do not have GPU
 access. You can redirect or suppress them if desired.
+
+## Asynchronous training
+
+You can keep the GPU busy by generating self-play data while training. Pass the
+`--workers` flag to `main.py` to launch background self-play processes that
+continuously fill the replay buffer. The training loop fetches the latest
+parameters for each batch so the workers automatically use the most recent
+model.


### PR DESCRIPTION
## Summary
- enable background self-play workers to fetch updated parameters
- support async workers in training loop
- expose new `--workers` flag in `main.py`
- document asynchronous training usage

## Testing
- `python -m py_compile drop_stack_ai/selfplay/self_play.py drop_stack_ai/training/train.py main.py`
- `python main.py --episodes 0 --steps 1 --cycles 1 --workers 1 --processes 1 --batch-size 4 --hidden-size 16 --checkpoint=/tmp/test.msgpack --mixed-precision` *(fails: new enum value must be None or in [...], got float16)*

------
https://chatgpt.com/codex/tasks/task_e_685d8be09bf88330910d97e8a2772135