### PR TITLE
Split actor/learner scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,3 +80,12 @@ You can keep the GPU busy by generating self-play data while training. Pass the
 continuously fill the replay buffer. The training loop fetches the latest
 parameters for each batch so the workers automatically use the most recent
 model.
+
+## Actor/Learner setup
+
+The pipeline can also run as two separate programs. ``actor.py`` repeatedly
+downloads the latest checkpoint, generates a batch of self‑play games and
+uploads the episodes to cloud storage. ``learner.py`` continuously reads these
+episode files, trains the network and periodically writes updated parameters
+back to the same storage location. This decouples data generation from the
+training loop so multiple actors can run in parallel.

--- a/actor.py
+++ b/actor.py
@@ -1,0 +1,83 @@
+import argparse
+import os
+import pickle
+import time
+
+import jax
+import jax.numpy as jnp
+
+from drop_stack_ai.model.network import create_model
+from drop_stack_ai.selfplay.self_play import self_play_parallel
+from drop_stack_ai.training.replay_buffer import ReplayBuffer
+from drop_stack_ai.utils.serialization import load_params, save_bytes
+
+
+def load_model(model_path: str, model, params):
+    try:
+        new_params = load_params(model_path, params)
+        return new_params
+    except FileNotFoundError:
+        print(f"[actor] model {model_path} not found; using existing params")
+        return params
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Self-play actor")
+    parser.add_argument("--model", type=str, required=True, help="Path to model parameters")
+    parser.add_argument("--output", type=str, required=True, help="Directory or gs:// bucket for episodes")
+    parser.add_argument("--episodes", type=int, default=50, help="Episodes per batch")
+    parser.add_argument("--processes", type=int, default=None, help="Parallel self-play processes")
+    parser.add_argument("--hidden-size", type=int, default=1024, help="Model hidden size")
+    parser.add_argument("--mixed-precision", action="store_true", help="Use float16 model")
+    parser.add_argument("--greedy-after", type=int, default=10, help="Moves before greedy play")
+    parser.add_argument("--sleep", type=int, default=30, help="Pause between batches (seconds)")
+    parser.add_argument("--seed", type=int, default=0, help="PRNG seed")
+    args = parser.parse_args()
+
+    rng = jax.random.PRNGKey(args.seed)
+    dtype = jnp.float16 if args.mixed_precision else jnp.float32
+    model, params = create_model(rng, hidden_size=args.hidden_size, dtype=dtype)
+    params = load_model(args.model, model, params)
+    last_stamp = None
+
+    while True:
+        # Reload model if file changed
+        try:
+            if args.model.startswith("gs://"):
+                from google.cloud import storage
+
+                bucket, blob_name = args.model[5:].split("/", 1)
+                client = storage.Client()
+                blob = client.bucket(bucket).blob(blob_name)
+                blob.reload()
+                stamp = blob.updated
+            else:
+                stamp = os.path.getmtime(args.model)
+        except Exception:
+            stamp = None
+        if stamp != last_stamp:
+            last_stamp = stamp
+            params = load_model(args.model, model, params)
+            print("[actor] loaded new model")
+
+        buffer = ReplayBuffer()
+        rng = self_play_parallel(
+            model,
+            params,
+            rng,
+            buffer,
+            episodes=args.episodes,
+            processes=args.processes,
+            greedy_after=args.greedy_after,
+        )
+        payload = pickle.dumps(buffer)
+        filename = f"episodes_{int(time.time())}.pkl"
+        out_path = os.path.join(args.output, filename)
+        save_bytes(payload, out_path)
+        print(f"[actor] saved {len(buffer)} steps to {out_path}")
+        if args.sleep:
+            time.sleep(args.sleep)
+
+
+if __name__ == "__main__":
+    main()

--- a/drop_stack_ai/training/replay_buffer.py
+++ b/drop_stack_ai/training/replay_buffer.py
@@ -45,3 +45,11 @@ class ReplayBuffer:
         import random
 
         return random.sample(self.data, batch_size)
+
+    def extend(self, other: "ReplayBuffer") -> None:
+        """Append all episodes from ``other`` into this buffer."""
+        for episode in other.episodes:
+            states = [item["state"] for item in episode]
+            policies = [item["policy"] for item in episode]
+            values = [item["value"] for item in episode]
+            self.add_episode(states, policies, values)

--- a/drop_stack_ai/utils/serialization.py
+++ b/drop_stack_ai/utils/serialization.py
@@ -1,18 +1,50 @@
 import os
 from typing import Any
 
+from google.cloud import storage
+
 from flax.serialization import to_bytes, from_bytes
+
+
+def _write_bytes(path: str, data: bytes) -> None:
+    if path.startswith("gs://"):
+        bucket, blob_name = path[5:].split("/", 1)
+        client = storage.Client()
+        bucket = client.bucket(bucket)
+        bucket.blob(blob_name).upload_from_string(data)
+    else:
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "wb") as f:
+            f.write(data)
 
 
 def save_params(params: Any, path: str) -> None:
     """Save model parameters to ``path`` using Flax serialization."""
-    os.makedirs(os.path.dirname(path), exist_ok=True)
-    with open(path, "wb") as f:
-        f.write(to_bytes(params))
+    _write_bytes(path, to_bytes(params))
+
+
+def _read_bytes(path: str) -> bytes:
+    if path.startswith("gs://"):
+        bucket, blob_name = path[5:].split("/", 1)
+        client = storage.Client()
+        bucket = client.bucket(bucket)
+        return bucket.blob(blob_name).download_as_bytes()
+    else:
+        with open(path, "rb") as f:
+            return f.read()
 
 
 def load_params(path: str, target: Any) -> Any:
     """Load parameters from ``path`` into ``target`` structure."""
-    with open(path, "rb") as f:
-        data = f.read()
+    data = _read_bytes(path)
     return from_bytes(target, data)
+
+
+def load_bytes(path: str) -> bytes:
+    """Load raw bytes from ``path`` which may be local or ``gs://``."""
+    return _read_bytes(path)
+
+
+def save_bytes(data: bytes, path: str) -> None:
+    """Write raw bytes to ``path`` which may be local or ``gs://``."""
+    _write_bytes(path, data)


### PR DESCRIPTION
## Summary
- add standalone `actor.py` for generating self‑play data
- add standalone `learner.py` for continuous training
- support GCS paths in `save_params` and `load_params`
- extend `ReplayBuffer` to merge other buffers
- allow checkpoints to be loaded from GCS
- document new actor/learner workflow

## Testing
- `python -m py_compile actor.py learner.py drop_stack_ai/utils/serialization.py drop_stack_ai/training/replay_buffer.py drop_stack_ai/training/train.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ef3840e6c833094c409e0d5379849