### PR TITLE
Fix CPU fallback for MCTS

### DIFF
--- a/drop_stack_ai/model/mcts.py
+++ b/drop_stack_ai/model/mcts.py
@@ -61,8 +61,11 @@ def run_mcts(
     first call.
     """
     if device is None:
-        gpus = jax.devices("gpu")
-        device = gpus[0] if gpus else jax.devices()[0]
+        try:
+            gpus = jax.devices("gpu")
+        except RuntimeError:
+            gpus = []
+        device = gpus[0] if gpus else jax.devices("cpu")[0]
 
     root = Node(prior=1.0)
 


### PR DESCRIPTION
## Summary
- handle absence of GPU platform gracefully when running MCTS

## Testing
- `python -m compileall -q drop_stack_ai actor.py learner.py main.py`
- `python - <<'PY'
import jax
from drop_stack_ai.model.network import create_model
from drop_stack_ai.env.drop_stack_env import DropStackEnv
from drop_stack_ai.model.mcts import run_mcts

rng = jax.random.PRNGKey(0)
model, params = create_model(rng)

env = DropStackEnv()
policy = run_mcts(model, params, env, num_simulations=1)
print('policy', policy)
PY`

------
https://chatgpt.com/codex/tasks/task_e_685f13b1c9f483308097f6c9e54ecf12