### PR TITLE
Add default bucket path for scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,3 +94,9 @@ log progress every ``--log-interval`` steps. The ``--init-episodes`` option
 seeds the replay buffer by running a bit of self-play locally before training
 begins. This decouples data generation from the training loop so multiple actors
 can run in parallel.
+
+Both scripts default to using the ``gs://drop-stack-ai-data-12345`` bucket for
+models and episode files. Simply running ``python learner.py`` and
+``python actor.py`` will therefore train and generate data using that bucket.
+You can override the location by setting the ``DROPSTACK_BUCKET`` environment
+variable or passing the ``--model``/``--data``/``--output`` flags explicitly.

--- a/actor.py
+++ b/actor.py
@@ -21,10 +21,25 @@ def load_model(model_path: str, model, params):
         return params
 
 
+DEFAULT_BUCKET = os.environ.get("DROPSTACK_BUCKET", "gs://drop-stack-ai-data-12345")
+DEFAULT_MODEL = os.path.join(DEFAULT_BUCKET, "checkpoints", "model.msgpack")
+DEFAULT_EPISODES = os.path.join(DEFAULT_BUCKET, "episodes")
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description="Self-play actor")
-    parser.add_argument("--model", type=str, required=True, help="Path to model parameters")
-    parser.add_argument("--output", type=str, required=True, help="Directory or gs:// bucket for episodes")
+    parser.add_argument(
+        "--model",
+        type=str,
+        default=DEFAULT_MODEL,
+        help="Path to model parameters",
+    )
+    parser.add_argument(
+        "--output",
+        type=str,
+        default=DEFAULT_EPISODES,
+        help="Directory or gs:// bucket for episodes",
+    )
     parser.add_argument("--episodes", type=int, default=50, help="Episodes per batch")
     parser.add_argument("--processes", type=int, default=None, help="Parallel self-play processes")
     parser.add_argument("--hidden-size", type=int, default=1024, help="Model hidden size")

--- a/learner.py
+++ b/learner.py
@@ -25,6 +25,11 @@ from drop_stack_ai.utils.serialization import (
 from google.cloud import storage
 
 
+DEFAULT_BUCKET = os.environ.get("DROPSTACK_BUCKET", "gs://drop-stack-ai-data-12345")
+DEFAULT_MODEL = os.path.join(DEFAULT_BUCKET, "checkpoints", "model.msgpack")
+DEFAULT_EPISODES = os.path.join(DEFAULT_BUCKET, "episodes")
+
+
 def load_buffer_bytes(data: bytes) -> ReplayBuffer:
     obj = pickle.loads(data)
     if isinstance(obj, ReplayBuffer):
@@ -48,8 +53,18 @@ def list_files(path: str) -> list[str]:
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Learner")
-    parser.add_argument("--data", type=str, required=True, help="Episode file directory or gs:// bucket")
-    parser.add_argument("--model", type=str, required=True, help="Path to save model parameters")
+    parser.add_argument(
+        "--data",
+        type=str,
+        default=DEFAULT_EPISODES,
+        help="Episode file directory or gs:// bucket",
+    )
+    parser.add_argument(
+        "--model",
+        type=str,
+        default=DEFAULT_MODEL,
+        help="Path to save model parameters",
+    )
     parser.add_argument("--hidden-size", type=int, default=1024)
     parser.add_argument("--mixed-precision", action="store_true")
     parser.add_argument("--batch-size", type=int, default=256)


### PR DESCRIPTION
## Summary
- make `actor.py` and `learner.py` default to `gs://drop-stack-ai-data-12345`
- document simple invocation of the actor/learner in the README

## Testing
- `python -m py_compile actor.py learner.py`

------
https://chatgpt.com/codex/tasks/task_e_685f2f8405848330bdc4908d9e6d57f5