### PR TITLE
Improve actor batching and learner file handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,10 @@ log progress every ``--log-interval`` steps. The ``--init-episodes`` option
 seeds the replay buffer by running a bit of self-play locally before training
 begins. This decouples data generation from the training loop so multiple actors
 can run in parallel.
+Episodes are bundled into larger files by ``actor.py`` using the
+``--episodes-per-file`` option for more efficient uploads. ``learner.py``
+polls cloud storage with exponential backoff and downloads files in parallel via
+``--download-workers``.
 
 Both scripts default to using the ``gs://drop-stack-ai-data-12345`` bucket for
 models and episode files. Simply running ``python learner.py`` and


### PR DESCRIPTION
## Summary
- batch episodes in actor before uploading
- add exponential backoff and parallel downloads to learner
- document new options in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f36a4ae408330b2dc06d9bc80511c