### PR TITLE
Enable GPU & speed up training

### DIFF
--- a/actor.py
+++ b/actor.py
@@ -3,6 +3,8 @@ import os
 import pickle
 import time
 
+os.environ.setdefault("JAX_PLATFORM_NAME", "gpu")
+
 import jax
 import jax.numpy as jnp
 

--- a/drop_stack_ai/training/data_loader.py
+++ b/drop_stack_ai/training/data_loader.py
@@ -69,7 +69,7 @@ def data_loader(
 
     def _iterator() -> Iterator[Dict[str, jnp.ndarray]]:
         while True:
-            while len(buffer) < batch_size:
+            while len(buffer) == 0:
                 time.sleep(0.01)
             samples = buffer.sample(batch_size)
             batch = _prepare_batch(samples)

--- a/drop_stack_ai/training/replay_buffer.py
+++ b/drop_stack_ai/training/replay_buffer.py
@@ -44,7 +44,9 @@ class ReplayBuffer:
         """Randomly sample ``batch_size`` elements from the buffer."""
         import random
 
-        return random.sample(self.data, batch_size)
+        if len(self.data) >= batch_size:
+            return random.sample(self.data, batch_size)
+        return random.choices(self.data, k=batch_size)
 
     def extend(self, other: "ReplayBuffer") -> None:
         """Append all episodes from ``other`` into this buffer."""

--- a/learner.py
+++ b/learner.py
@@ -3,6 +3,8 @@ import os
 import pickle
 import time
 import threading
+
+os.environ.setdefault("JAX_PLATFORM_NAME", "gpu")
 from typing import Set
 from concurrent.futures import ThreadPoolExecutor
 
@@ -69,7 +71,7 @@ def main() -> None:
     )
     parser.add_argument("--hidden-size", type=int, default=1024)
     parser.add_argument("--mixed-precision", action="store_true")
-    parser.add_argument("--batch-size", type=int, default=256)
+    parser.add_argument("--batch-size", type=int, default=512)
     parser.add_argument("--learning-rate", type=float, default=2e-3)
     parser.add_argument("--buffer-size", type=int, default=200_000)
     parser.add_argument("--save-every", type=int, default=300)
@@ -169,7 +171,7 @@ def main() -> None:
     step = 0
     try:
         while True:
-            if len(buffer) < args.batch_size:
+            if len(buffer) == 0:
                 time.sleep(0.1)
                 continue
 

--- a/main.py
+++ b/main.py
@@ -1,6 +1,8 @@
 import os
 import argparse
 
+os.environ.setdefault("JAX_PLATFORM_NAME", "gpu")
+
 import jax
 import jax.numpy as jnp
 
@@ -92,7 +94,7 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Run Drop Stack 2048 training cycle")
     parser.add_argument("--episodes", type=int, default=20000, help="Number of self-play episodes")
     parser.add_argument("--steps", type=int, default=100000, help="Training steps")
-    parser.add_argument("--batch-size", type=int, default=256, help="Batch size")
+    parser.add_argument("--batch-size", type=int, default=512, help="Batch size")
     parser.add_argument("--learning-rate", type=float, default=2e-3, help="Learning rate")
     parser.add_argument("--hidden-size", type=int, default=1024, help="Model hidden size")
     parser.add_argument(


### PR DESCRIPTION
## Summary
- default to GPU execution with `JAX_PLATFORM_NAME`
- increase default batch size to 512
- allow oversampling in `ReplayBuffer.sample`
- start training when any data is available

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_685f39f12fb88330b5a974659fac67d3