### PR TITLE
Force CPU usage in actor

### DIFF
--- a/actor.py
+++ b/actor.py
@@ -3,7 +3,9 @@ import os
 import pickle
 import time
 
-os.environ.setdefault("JAX_PLATFORM_NAME", "gpu")
+# Force CPU-only usage regardless of system configuration
+os.environ["JAX_PLATFORM_NAME"] = "cpu"
+os.environ["CUDA_VISIBLE_DEVICES"] = ""
 
 import jax
 import jax.numpy as jnp


### PR DESCRIPTION
## Summary
- enforce CPU-only execution in actor.py by clearing GPU environment variables

## Testing
- `python -m py_compile actor.py`

------
https://chatgpt.com/codex/tasks/task_e_685f41a39b7c8330bb519e16a49620b2