### PR TITLE
Ensure actor uses all CPU cores

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ background thread so the GPU remains busy. Mixed precision can be enabled with
 the `--mixed-precision` flag to reduce memory usage and speed up training.
 
 You can speed up data generation by running multiple self-play episodes in
-parallel using the `--processes` option.
+parallel using the `--processes` option. If not specified, `actor.py` uses the
+number of CPU cores so all available processors participate.
 
 After each training cycle the new model plays a set of test games to measure
 its average score. If this score beats the previous best, the checkpoint is

--- a/actor.py
+++ b/actor.py
@@ -51,7 +51,12 @@ def main() -> None:
         default=200,
         help="Number of episodes to bundle into each uploaded file",
     )
-    parser.add_argument("--processes", type=int, default=None, help="Parallel self-play processes")
+    parser.add_argument(
+        "--processes",
+        type=int,
+        default=os.cpu_count(),
+        help="Parallel self-play processes (defaults to all CPU cores)",
+    )
     parser.add_argument("--hidden-size", type=int, default=1024, help="Model hidden size")
     parser.add_argument("--mixed-precision", action="store_true", help="Use float16 model")
     parser.add_argument("--greedy-after", type=int, default=10, help="Moves before greedy play")
@@ -103,7 +108,7 @@ def main() -> None:
             rng,
             buffer,
             episodes=args.episodes,
-            processes=args.processes,
+            processes=args.processes or os.cpu_count(),
             greedy_after=args.greedy_after,
         )
         batch_buffer.extend(buffer)


### PR DESCRIPTION
## Summary
- default `--processes` uses `os.cpu_count()` so the actor spawns one worker per CPU core
- clarify this behaviour in the README
- handle `None` in actor when launching parallel self-play

## Testing
- `python -m py_compile actor.py`

------
https://chatgpt.com/codex/tasks/task_e_685f566ded308330a3e9390f1eb4bd1d