### PR TITLE
Stop merge module from printing startup info

### DIFF
--- a/drop_stack_ai/env/merge.py
+++ b/drop_stack_ai/env/merge.py
@@ -13,10 +13,6 @@ except Exception:  # pragma: no cover - optional dependency
     _cpp_drop_resolve_and_score = None
 
 USING_CPP = _cpp_drop_resolve_and_score is not None
-if USING_CPP:
-    print("[merge] Using C++ merge implementation")
-else:
-    print("[merge] Using Python merge implementation")
 
 
 Board = List[List[int]]


### PR DESCRIPTION
## Summary
- remove startup print from `drop_stack_ai.env.merge`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860ad650f308330b9bf9e1aa6b7b79a