### PR TITLE
Enable JAX memory preallocation in learner

### DIFF
--- a/learner.py
+++ b/learner.py
@@ -5,7 +5,7 @@ import time
 import threading
 
 os.environ.setdefault("JAX_PLATFORM_NAME", "gpu")
-os.environ.setdefault("XLA_PYTHON_CLIENT_PREALLOCATE", "false")
+os.environ.setdefault("XLA_PYTHON_CLIENT_PREALLOCATE", "true")
 os.environ.setdefault("XLA_PYTHON_CLIENT_MEM_FRACTION", "0.90")
 os.environ.setdefault(
     "XLA_FLAGS",


### PR DESCRIPTION
## Summary
- toggle XLA_PYTHON_CLIENT_PREALLOCATE to `true` so GPU memory is preallocated

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686213bc27008330b7e38c376cc93b62