### PR TITLE
Improve training logs

### DIFF
--- a/learner.py
+++ b/learner.py
@@ -257,7 +257,7 @@ def main() -> None:
             if step % args.log_interval == 0:
                 metrics = jax.tree_util.tree_map(lambda x: float(jnp.mean(x)), metrics)
                 print(
-                    f"step {step}: loss={metrics['loss']:.4f} "
+                    f"[learner] step {step}/{args.steps} | loss: {metrics['loss']:.4f} "
                     f"policy_loss={metrics['policy_loss']:.4f} value_loss={metrics['value_loss']:.4f}"
                 )
 


### PR DESCRIPTION
## Summary
- add average score and steps reporting when actor uploads episodes
- extend `self_play_parallel` to optionally return stats
- print learner progress with total steps

## Testing
- `pytest -q`
- `python actor.py --help`
- `python learner.py --help`


------
https://chatgpt.com/codex/tasks/task_e_686227681df08330816504e987469e75