### PR TITLE
Adjust default training parameters

### DIFF
--- a/actor.py
+++ b/actor.py
@@ -65,7 +65,7 @@ def main() -> None:
     parser.add_argument(
         "--hidden-size",
         type=int,
-        default=1024,
+        default=512,
         help="Model hidden size (match learner)",
     )
     parser.add_argument(

--- a/drop_stack_ai/training/train.py
+++ b/drop_stack_ai/training/train.py
@@ -56,7 +56,7 @@ class TrainConfig:
     batch_size: int = 512
     steps: int = 100_000
     learning_rate: float = 2e-3
-    hidden_size: int = 1024
+    hidden_size: int = 512
     log_interval: int = 10
     checkpoint_path: Optional[str] = None
     workers: int = 0
@@ -261,7 +261,7 @@ if __name__ == "__main__":
         "--learning-rate", type=float, default=2e-3, help="Learning rate"
     )
     parser.add_argument(
-        "--hidden-size", type=int, default=1024, help="Model hidden size"
+        "--hidden-size", type=int, default=512, help="Model hidden size"
     )
     parser.add_argument(
         "--mixed-precision",

--- a/learner.py
+++ b/learner.py
@@ -111,10 +111,10 @@ def main() -> None:
         default=DEFAULT_LATEST,
         help="gs:// path for the continuously updated model",
     )
-    parser.add_argument("--hidden-size", type=int, default=1024)
+    parser.add_argument("--hidden-size", type=int, default=512)
     parser.add_argument("--mixed-precision", action="store_true")
     parser.add_argument(
-        "--batch-size", type=int, default=2048, help="Maximizes GPU usage."
+        "--batch-size", type=int, default=1024, help="Maximizes GPU usage."
     )
     parser.add_argument(
         "--learning-rate",
@@ -153,7 +153,7 @@ def main() -> None:
         help="Parallel downloads for episodes.",
     )
     parser.add_argument(
-        "--log-interval", type=int, default=200, help="Reduce logging overhead."
+        "--log-interval", type=int, default=8, help="Reduce logging overhead."
     )
     parser.add_argument(
         "--init-episodes",

--- a/main.py
+++ b/main.py
@@ -96,7 +96,7 @@ def main() -> None:
     parser.add_argument("--steps", type=int, default=100000, help="Training steps")
     parser.add_argument("--batch-size", type=int, default=512, help="Batch size")
     parser.add_argument("--learning-rate", type=float, default=2e-3, help="Learning rate")
-    parser.add_argument("--hidden-size", type=int, default=1024, help="Model hidden size")
+    parser.add_argument("--hidden-size", type=int, default=512, help="Model hidden size")
     parser.add_argument(
         "--mixed-precision",
         action="store_true",


### PR DESCRIPTION
## Summary
- cut model hidden size from 1024 to 512
- lower learner batch size from 2048 to 1024
- log learner metrics every fused batch

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6864f4a0988c83309fd8bdb523a5dae6